### PR TITLE
[Fix] streaming: do not reset timeout for each chunk emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ $: npm run test
 
 - [Teams Developer Portal: Apps](https://dev.teams.microsoft.com/apps)
 - [Teams Toolkit](https://www.npmjs.com/package/@microsoft/teamsapp-cli)
+
+<!-- PR #378 demo -->


### PR DESCRIPTION
Issue : https://github.com/microsoft/teams.ts/issues/374

Main change::
- In emit, instead of cancelling and scheduling a new timeout, 
      - flush immediately if no timeout pending, 
      - else push to queue and wait.
- Added tests for streaming

https://github.com/user-attachments/assets/d8fc0a16-21f9-4ddc-a681-5db5e200e192

Devtools: Streaming always starts before the full response is received (check with logs, see attached video).
Teams: Even though the first chunk is emitted immediately, (sometimes) by the time the stream starts on Teams, the full response is ready. In the second msg, we can see the stream starts a little bit before the full response is printed.
