### PR TITLE
[Fix] streaming: Remove jitter during streaming 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ $: npm run test
 
 - [Teams Developer Portal: Apps](https://dev.teams.microsoft.com/apps)
 - [Teams Toolkit](https://www.npmjs.com/package/@microsoft/teamsapp-cli)
+
+<!-- [Fix] streaming: do not reset timeout for each chunk emit -->


### PR DESCRIPTION
With jitter=full, sometimes we reduce our waits too too short (like if it was going to be 2s, it becomes like 0.5s). This leads to us eating through all our retries and getting a 429. Our service more aggressive than originally thought, so we need to keep jitter to none.

https://github.com/user-attachments/assets/d8fc0a16-21f9-4ddc-a681-5db5e200e192

