### PR TITLE
TeamsChannelAccount required for certain APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ $: npm run test
 
 - [Teams Developer Portal: Apps](https://dev.teams.microsoft.com/apps)
 - [Teams Toolkit](https://www.npmjs.com/package/@microsoft/teamsapp-cli)
+
+<!-- TeamsChannelAccount required for certain APIs -->


### PR DESCRIPTION
Teams uses two different account schemes depending on the API, this PR updates the type definitions so that  conversation.members and meetingInfo/meetingParticipant APIs return `TeamsChannelAccount` instead of the generic `Account`