### PR TITLE
Migrate a2a client to sdk v 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ $: npm run test
 
 - [Teams Developer Portal: Apps](https://dev.teams.microsoft.com/apps)
 - [Teams Toolkit](https://www.npmjs.com/package/@microsoft/teamsapp-cli)
+
+<!-- Migrate a2a client to sdk v 0.3.0 -->


### PR DESCRIPTION
1. Removes all older code dealing with a2a. I had written the previous code in the absence of an official a2a js library. Which is no longer the case. Now there is https://github.com/a2aproject/a2a-js. So all the client-calling, schema types etc code can now be safely removed.
2. I replaced the existing ChatPrompt plugin with the new plugin. The interface is pretty much exactly the same, but I add a couple more options to be able to customize the message that's being set to a particular agent via `buildMessageForAgent`, and customize the message coming back from the agent via `buildMessageFromAgentResponse`

Example of both server and client working. Here we have the server (shown in tests/a2a/server), and the client (tests/a2a/client), and the client is able to send a message to the server agent to ask it the weather and get a response successfully.

https://github.com/user-attachments/assets/c3330d4c-e8d5-482f-8834-ae0ee727fd5b










#### PR Dependency Tree


* **PR #338** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)