### PR TITLE
[Fix] streaming: do not reset timeout for each chunk emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ $: npm run test
 
 - [Teams Developer Portal: Apps](https://dev.teams.microsoft.com/apps)
 - [Teams Toolkit](https://www.npmjs.com/package/@microsoft/teamsapp-cli)
+
+<!-- [Fix] streaming: do not reset timeout for each chunk emit -->


### PR DESCRIPTION
With jitter=full, sometimes we reduce our waits too too short (like if it was going to be 2s, it becomes like 0.5s). This leads to us eating through all our retries and getting a 429. Our service more aggressive than originally thought, so we need to keep jitter to none.

https://github.com/user-attachments/assets/f44021c1-33f2-4e86-bfe9-65d80cdd97fd

